### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -420,12 +420,12 @@ class AuthenticateView(BaseAPIView):
         
         try:
             result = digilocker_client.request_otp(phone_number)
-            logger.info(f"Authentication initiated for {phone_number}")
+            logger.info("Authentication initiated for a user phone number")
             return Response(result, status=status.HTTP_200_OK)
         except DigiLockerError as e:
             error_message = str(e)
             if "User not found or inactive" in error_message:
-                logger.warning(f"Authentication failed for {phone_number}: User not registered")
+                logger.warning("Authentication failed: User not registered for submitted phone number")
                 return Response(
                     {
                         'error': 'User not found', 
@@ -435,13 +435,13 @@ class AuthenticateView(BaseAPIView):
                     status=status.HTTP_404_NOT_FOUND
                 )
             else:
-                logger.warning(f"Authentication failed for {phone_number}: {error_message}")
+                logger.warning(f"Authentication failed: {error_message}")
                 return Response(
                     {'error': 'Authentication failed', 'message': error_message},
                     status=status.HTTP_400_BAD_REQUEST
                 )
         except (ValidationError, NotFoundError) as e:
-            logger.warning(f"Authentication failed for {phone_number}: {str(e)}")
+            logger.warning(f"Authentication failed: {str(e)}")
             raise
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/frankmathewsajan/AGSA/security/code-scanning/18](https://github.com/frankmathewsajan/AGSA/security/code-scanning/18)

To resolve the issue, amend every log line in this file that emits the user's `phone_number` to avoid direct output in logs. Instead of logging the full phone number, you may log a redacted version (e.g., partially masked digits), or simply exclude it altogether if not strictly necessary for operations. Avoid logging the full sensitive string. Since this only appears in exception logging (lines 428, 438, 444 in `AuthenticateView`), change these to remove or redact the phone number.

**Best approach:**  
- For all logger calls that include `{phone_number}` in informational or warning messages, redact or omit the phone number from the log message.
- If you prefer, you can log a masked version (e.g., last two digits), but simplest and safest is to omit it entirely, or replace with a static or generic placeholder (`[REDACTED]`, `[user]`, etc.).

**Implementation details:**  
- Replace lines that log messages containing `phone_number` (lines 423, 428, 438, 444) with versions that do not expose the actual value.
- No new imports or external libraries are needed for simple redaction/omission.
- Only lines that emit logs including the phone number need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
